### PR TITLE
build_aot.sh and Dockerfile.AOT fixes

### DIFF
--- a/bin/build_aot.sh
+++ b/bin/build_aot.sh
@@ -1,10 +1,16 @@
-#! /bin/bash -e
+#!/bin/bash -e
+set -o pipefail
 
 ###
 # This is a script to help compile a Flutter app in AOT (ahead-of-time) mode.
 # AOT compiled Flutter apps will run significantly faster than JIT apps when
 # on embedded devices.
 ###
+
+if [[ -z "$1" ]] || [[ -z "$2" ]] || [[ -z "$3" ]]; then
+  echo "Usage: $0 <self_path> <app_package_name> <flutter_sdk>"
+  exit 1
+fi
 
 HOST_OS=$(uname -s)
 HOST_ARCH=$(uname -m)
@@ -20,9 +26,14 @@ FLUTTER_SDK=$3
 # the simarm64 target is only supported on x86_64 Linux hosts.
 if [[ $HOST_ARCH != "x86_64" ]] || [[ $HOST_OS != "Linux" ]]; then
   echo "🐳 Not on Linux x86_64... going to try using Docker!"
-  docker build $SELF_PATH -f $SELF_PATH/docker/Dockerfile.AOT -t flutter-aot-builder
-  docker run --rm --platform=linux/amd64 -t -e APP_PACKAGE_NAME="$APP_PACKAGE_NAME" -v $(pwd):/data flutter-aot-builder
+  docker build --platform linux/amd64 "$SELF_PATH" -f "$SELF_PATH/docker/Dockerfile.AOT" -t flutter-aot-builder
+  docker run --rm --platform=linux/amd64 -t -e APP_PACKAGE_NAME="$APP_PACKAGE_NAME" -v "$(pwd):/data" flutter-aot-builder
   exit
+fi
+
+if [[ ! -f "pubspec.yaml" ]]; then
+  echo "Error: must be run from a flutter project root."
+  exit 1
 fi
 
 # Clean up and rebuild everything to be sure we're in a clean build state
@@ -31,22 +42,22 @@ flutter pub get
 
 # Create required directories for bundle output
 mkdir -p .dart_tool/flutter_build/flutter-embedded-linux
-mkdir -p ${RESULT_DIR}/${BUILD_MODE}/bundle/lib/
-mkdir -p ${RESULT_DIR}/${BUILD_MODE}/bundle/data/
+mkdir -p "${RESULT_DIR}/${BUILD_MODE}/bundle/lib/"
+mkdir -p "${RESULT_DIR}/${BUILD_MODE}/bundle/data/"
 
 echo "🔨 Building an AOT bundle for '$APP_PACKAGE_NAME' ($BUILD_MODE)..."
 
 # Build assets bundle
-flutter build bundle --asset-dir=${RESULT_DIR}/${BUILD_MODE}/bundle/data/flutter_assets --no-version-check
+flutter build bundle --asset-dir="${RESULT_DIR}/${BUILD_MODE}/bundle/data/flutter_assets" --no-version-check
 
 # Copy over icudtl.dat (unicode and globalization support data)
-cp ${FLUTTER_SDK}/cache/artifacts/engine/linux-x64/icudtl.dat ${RESULT_DIR}/${BUILD_MODE}/bundle/data/
+cp "${FLUTTER_SDK}/cache/artifacts/engine/linux-x64/icudtl.dat" "${RESULT_DIR}/${BUILD_MODE}/bundle/data/"
 
 # Build the Dart app's kernel snapshot
 ${FLUTTER_SDK}/cache/dart-sdk/bin/dartaotruntime \
   --verbose \
-  --disable-dart-dev ${FLUTTER_SDK}/cache/artifacts/engine/linux-x64/frontend_server_aot.dart.snapshot \
-  --sdk-root ${FLUTTER_SDK}/cache/artifacts/engine/common/flutter_patched_sdk_product/ \
+  --disable-dart-dev "${FLUTTER_SDK}/cache/artifacts/engine/linux-x64/frontend_server_aot.dart.snapshot" \
+  --sdk-root "${FLUTTER_SDK}/cache/artifacts/engine/common/flutter_patched_sdk_product/" \
   --target=flutter \
   --no-print-incremental-dependencies \
   -Ddart.vm.profile=false \
@@ -56,14 +67,14 @@ ${FLUTTER_SDK}/cache/dart-sdk/bin/dartaotruntime \
   --packages .dart_tool/package_config.json \
   --output-dill .dart_tool/flutter_build/flutter-embedded-linux/app.dill \
   --depfile .dart_tool/flutter_build/flutter-embedded-linux/kernel_snapshot.d \
-  package:${APP_PACKAGE_NAME}/main.dart
+  "package:${APP_PACKAGE_NAME}/main.dart"
 
 # Print version info, it's useful :)
 flutter --version --no-version-check
-$SELF_PATH/bin/gen_snapshot --version
+"$SELF_PATH/bin/gen_snapshot" --version
 
 # Build the ARM64 (simarm) shared library (AOT compilied Dart code)
-$SELF_PATH/bin/gen_snapshot \
+"$SELF_PATH/bin/gen_snapshot" \
   --deterministic \
   --snapshot_kind=app-aot-elf \
   --elf=.dart_tool/flutter_build/flutter-embedded-linux/libapp.so \
@@ -71,4 +82,4 @@ $SELF_PATH/bin/gen_snapshot \
   .dart_tool/flutter_build/flutter-embedded-linux/app.dill
 
 # Copy AOT binary into result directory to complete the bundle
-cp .dart_tool/flutter_build/flutter-embedded-linux/libapp.so ${RESULT_DIR}/${BUILD_MODE}/bundle/lib/
+cp .dart_tool/flutter_build/flutter-embedded-linux/libapp.so "${RESULT_DIR}/${BUILD_MODE}/bundle/lib/"

--- a/docker/Dockerfile.AOT
+++ b/docker/Dockerfile.AOT
@@ -1,19 +1,23 @@
-FROM --platform=linux/amd64 debian:bookworm-20240423
-RUN apt update
-RUN apt install -y wget curl xz-utils git
-RUN git config --global --add safe.directory /flutter
+FROM debian:bookworm-20240423
 
 ENV FLUTTER_VERSION="3.32.8"
-RUN wget --no-verbose https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_$FLUTTER_VERSION-stable.tar.xz
-RUN tar xf flutter_linux_$FLUTTER_VERSION-stable.tar.xz -C /
 ENV PATH="$PATH:/flutter/bin"
 
-RUN flutter --disable-analytics
-RUN dart --disable-analytics
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       wget curl xz-utils git ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && wget --no-verbose \
+       "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz" \
+    && tar xf "flutter_linux_${FLUTTER_VERSION}-stable.tar.xz" -C / \
+    && rm "flutter_linux_${FLUTTER_VERSION}-stable.tar.xz" \
+    && git config --global --add safe.directory /flutter \
+    && flutter --disable-analytics \
+    && dart --disable-analytics
 
 RUN mkdir -p /tools/bin
-COPY bin/build_aot.sh /tools/bin
-COPY bin/gen_snapshot /tools/bin
+COPY bin/build_aot.sh /tools/bin/
+COPY bin/gen_snapshot /tools/bin/
 
 WORKDIR /data
-ENTRYPOINT /tools/bin/build_aot.sh /tools ${APP_PACKAGE_NAME} /flutter/bin
+ENTRYPOINT ["/bin/sh", "-c", "/tools/bin/build_aot.sh /tools \"${APP_PACKAGE_NAME}\" /flutter/bin"]


### PR DESCRIPTION
Fix Dockerfile warnings and harden build_aot.sh

dockerfile:
- fix warnings:
 1. `FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64"`
 2. `JSONArgsRecommended: JSON arguments recommended for ENTRYPOINT to prevent unintended behavior related to OS signals`
 - consolidated run layers
 - additional cleanup
 - `--no-install-recommends` and added `ca-certificates`

build_aot.sh:
- shebang space fix
- add `set -o pipefail`
- added argument validation and flutter project check
- quot var expansions

Im tested this only on mac but seems all must be ok.